### PR TITLE
[sdlf-cicd] generic: pin seed-farmer version

### DIFF
--- a/sdlf-cicd/template-cicd-generic-git.yaml
+++ b/sdlf-cicd/template-cicd-generic-git.yaml
@@ -212,7 +212,7 @@ Resources:
                   python3 -m venv .venv
                   source .venv/bin/activate
                   pip3 install --upgrade pip setuptools
-                  pip3 install seed-farmer
+                  pip3 install "seed-farmer~=5.0.2"
                 - |-
                   echo "project: sdlf" > seedfarmer.yaml
                   seedfarmer version


### PR DESCRIPTION
*Description of changes:*
seed-farmer version 6.x breaks the CodeBuild project so we pin it to the previous version for now.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
