### PR TITLE
[sdlf-cicd] use pcodebuildsuffix in artifacts bucket name

### DIFF
--- a/sdlf-cicd/template-cicd-generic-git.yaml
+++ b/sdlf-cicd/template-cicd-generic-git.yaml
@@ -76,7 +76,7 @@ Resources:
         !If [
           UseCustomBucketPrefix,
           !Sub "${pCustomBucketPrefix}-cicd-cfn-artifacts",
-          !Sub "sdlf-${AWS::Region}-${AWS::AccountId}-cicd-cfn-artifacts",
+          !Sub "sdlf-${AWS::Region}-${AWS::AccountId}-${pCodeBuildSuffix}-cicd-cfn-artifacts",
         ]
       BucketEncryption:
         ServerSideEncryptionConfiguration:
@@ -438,5 +438,7 @@ Resources:
               - "*"
               - "**/*"
 
-
-
+Outputs:
+  oArtifactsBucket:
+    Description: Name of the Artifacts S3 bucket
+    Value: !Ref rArtifactsBucket


### PR DESCRIPTION
*Description of changes:*
[sdlf-cicd] use pcodebuildsuffix in artifacts bucket name

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
