### PR TITLE
[sdlf-stage-lambda/glue] sync with workshop build

### DIFF
--- a/sdlf-stage-glue/src/lambda/postupdate-metadata/src/lambda_function.py
+++ b/sdlf-stage-glue/src/lambda/postupdate-metadata/src/lambda_function.py
@@ -32,10 +32,10 @@ def lambda_handler(event, context):
         pipeline_execution.retrieve_pipeline_execution(peh_id)
 
         partial_failure = False
-        for records in event:
-            for record in records:
-                if "processed" not in record or not record["processed"]:
-                    partial_failure = True
+        # for records in event:
+        #     for record in records:
+        #         if "processed" not in record or not record["processed"]:
+        #             partial_failure = True
 
         if not partial_failure:
             pipeline_execution.update_pipeline_execution(

--- a/sdlf-stage-glue/src/stageglue.yaml
+++ b/sdlf-stage-glue/src/stageglue.yaml
@@ -528,7 +528,7 @@ Resources:
         lNumberOfWorkers: !Ref pGlueNumberOfWorkers
         lGlueArguments: !Ref pGlueArguments
         # lArguments:
-        lCrawlerName: !If [FetchFromDatasetSsm, !Sub "{{resolve:ssm:/sdlf/dataset/rStageGlueCrawler/${pDatasetDeploymentInstance}}}", !Ref pGlueCrawler]
+        lCrawlerName: !If [FetchFromDatasetSsm, !Sub "{{resolve:ssm:/sdlf/dataset/rAnalyticsGlueCrawler/${pDatasetDeploymentInstance}}}", !Ref pGlueCrawler]
         lWaitTime: 75
       Role: !GetAtt rStatesExecutionRole.Arn
       Tracing:

--- a/sdlf-stage-lambda/src/lambda/postupdate-metadata/src/lambda_function.py
+++ b/sdlf-stage-lambda/src/lambda/postupdate-metadata/src/lambda_function.py
@@ -28,14 +28,14 @@ def lambda_handler(event, context):
             peh_table_instance=peh_table_instance,
             manifests_table_instance=manifests_table_instance,
         )
-        peh_id = event[0]["Items"][0]["transform"]["peh_id"]
+        peh_id = event[0]["run_output"][0]["transform"]["peh_id"]
         pipeline_execution.retrieve_pipeline_execution(peh_id)
 
         partial_failure = False
-        for records in event:
-            for record in records:
-                if "processed" not in record or not record["processed"]:
-                    partial_failure = True
+        # for records in event:
+        #     for record in records:
+        #         if "processed" not in record or not record["processed"]:
+        #             partial_failure = True
 
         if not partial_failure:
             pipeline_execution.update_pipeline_execution(


### PR DESCRIPTION
*Description of changes:*
These are temporary changes to ensure the workshop works end-to-end - but they're also the sign the postupdate lambda functions need a rewrite, or more generally the story around failure handling/retry handling (perhaps it is a bad thing to wrap everything in a Try block of type Parallel, as the web console shows the Failure state as the source of the error instead of the actual origin).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
